### PR TITLE
Fixed the issue of NaN values in Common_data before PCA.

### DIFF
--- a/SpaGE/main.py
+++ b/SpaGE/main.py
@@ -58,6 +58,9 @@ def SpaGE(Spatial_data,RNA_data,n_pv,genes_to_predict=None):
     Spatial_data_scaled = pd.DataFrame(data=st.zscore(Spatial_data,axis=0),
                                    index = Spatial_data.index,columns=Spatial_data.columns)
     Common_data = RNA_data_scaled[np.intersect1d(Spatial_data_scaled.columns,RNA_data_scaled.columns)]
+    if Common_data.isnull().any().any():
+        raise ValueError("NaN values detected in Common_data after scaling. Maybe you forgot to delete lowly-expressed gene?")
+    Common_data = Common_data.dropna(axis=1, how='all')
 
     Y_train = RNA_data[genes_to_predict]
     


### PR DESCRIPTION
Users will not have to update the scrna data for removal of lowly-expressed genes manually. (0 expression)
If any gene is found in the common data with all 0s in cell expression, remove it before prepping it for PCA. (standard deviation comes out to be 0 which causes NaN values after z-score normalization.)